### PR TITLE
Add placeholder .env

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,3 @@
+CODELOCKS_BASE_URI=http://placeholder.com
+CODELOCKS_API_KEY=placeholder_api_key
+CODELOCKS_ACCESS_KEY=placeholder_access_key

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Codelocks.access_key = "argh"
 
 API documentation with information on methods is [available on RubyDoc.info](http://www.rubydoc.info/github/kansohq/codelocks/master).
 
+## Tests
+
+The test suite can be run locally using the following commands:
+
+```
+$ cp .env.test .env
+$ dotenv
+$ bundle exec rspec
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/codelocks/fork )


### PR DESCRIPTION
This PR adds a placeholder `.env` file at `.env.test` and adds a little bit of documentation to help someone new to the project get up and running quickly.